### PR TITLE
#23 bind listeners before child components have a chance to emit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-event-hook",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A library for emitting and listening to events in a React application",
   "license": "MIT",
   "keywords": [
@@ -33,7 +33,7 @@
     "predev": "yarn cleanup",
     "prebuild": "yarn cleanup",
     "cleanup": "rm -rf ./dist",
-    "test": "jest src --coverage --verbose --runInBand",
+    "test": "jest src --coverage --verbose",
     "coverage": "coveralls < ./coverage/lcov.info"
   },
   "peerDependencies": {

--- a/src/hooks/event.hook.test.tsx
+++ b/src/hooks/event.hook.test.tsx
@@ -1,0 +1,66 @@
+import React, { FC, useState } from "react";
+import { render } from "@testing-library/react";
+import { useEvent } from "./event.hook";
+
+describe("useEvent", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "error").mockRestore();
+  });
+
+  it("should always return the same ref between renders", () => {
+    const handlerRefs: (() => any)[] = [];
+
+    const Component: FC = () => {
+      const eventHandler = useEvent(jest.fn());
+      handlerRefs.push(eventHandler);
+      return null;
+    };
+
+    render(<Component />).rerender(<Component />);
+    expect(handlerRefs[0]).toBe(handlerRefs[1]);
+  });
+
+  it("should give handlers access to the latest state", () => {
+    const countSpy = jest.fn();
+
+    const Component = () => {
+      const [count, setCount] = useState(0);
+      const getCount = useEvent(() => countSpy(count));
+      const incrementCount = () => setCount(count + 1);
+
+      return (
+        <>
+          <button
+            data-testid="increment-count-button"
+            onClick={incrementCount}
+          />
+          <button data-testid="get-count-button" onClick={getCount} />
+        </>
+      );
+    };
+
+    const { getByTestId } = render(<Component />);
+
+    const incrementCountButton = getByTestId("increment-count-button");
+    const getCountButton = getByTestId("get-count-button");
+
+    incrementCountButton.click();
+    incrementCountButton.click();
+    getCountButton.click();
+
+    expect(countSpy).toBeCalledWith(2);
+  });
+
+  it("should throw an error if the handler gets called during the first render", () => {
+    jest.spyOn(console, "error").mockImplementation();
+
+    const Component: FC = () => {
+      useEvent(jest.fn())();
+      return null;
+    };
+
+    expect(() => render(<Component />)).toThrowError(
+      "Cannot call an event handler during the first render."
+    );
+  });
+});

--- a/src/hooks/event.hook.ts
+++ b/src/hooks/event.hook.ts
@@ -1,0 +1,19 @@
+import { useCallback, useRef } from "react";
+import { useIsomorphicLayoutEffect } from "./layout-effect.hook";
+
+type AnyFunction = (...args: any[]) => any;
+
+export const useEvent = <T extends AnyFunction>(handler?: T) => {
+  const handlerRef = useRef<AnyFunction | undefined>(() => {
+    throw new Error("Cannot call an event handler during the first render.");
+  });
+
+  useIsomorphicLayoutEffect(() => {
+    handlerRef.current = handler;
+  });
+
+  return useCallback<AnyFunction>(
+    (...args) => handlerRef.current?.apply(null, args),
+    []
+  ) as T;
+};

--- a/src/hooks/layout-effect.hook.ssr.test.ts
+++ b/src/hooks/layout-effect.hook.ssr.test.ts
@@ -1,0 +1,12 @@
+/**
+ * @jest-environment node
+ */
+
+import { useEffect } from "react";
+import { useIsomorphicLayoutEffect } from "./layout-effect.hook";
+
+describe("useIsomorphicLayoutEffect (SSR)", () => {
+  it("should return useEffect from the server", () => {
+    expect(useIsomorphicLayoutEffect).toBe(useEffect);
+  });
+});

--- a/src/hooks/layout-effect.hook.test.ts
+++ b/src/hooks/layout-effect.hook.test.ts
@@ -1,0 +1,8 @@
+import { useLayoutEffect } from "react";
+import { useIsomorphicLayoutEffect } from "./layout-effect.hook";
+
+describe("useIsomorphicLayoutEffect", () => {
+  it("should return useLayoutEffect from the client", () => {
+    expect(useIsomorphicLayoutEffect).toBe(useLayoutEffect);
+  });
+});

--- a/src/hooks/layout-effect.hook.ts
+++ b/src/hooks/layout-effect.hook.ts
@@ -1,0 +1,6 @@
+import { useEffect, useLayoutEffect } from "react";
+import { canUseDom } from "../utils/dom";
+
+export const useIsomorphicLayoutEffect = canUseDom
+  ? useLayoutEffect
+  : useEffect;

--- a/src/hooks/storage.hook.ts
+++ b/src/hooks/storage.hook.ts
@@ -1,11 +1,14 @@
-import { useEffect } from "react";
+import { useEvent } from "./event.hook";
+import { useIsomorphicLayoutEffect } from "./layout-effect.hook";
 
 export const useStorageListener = (handler: (event: StorageEvent) => void) => {
-  useEffect(() => {
-    window.addEventListener("storage", handler);
+  const eventHandler = useEvent(handler);
+
+  useIsomorphicLayoutEffect(() => {
+    window.addEventListener("storage", eventHandler);
 
     return () => {
-      window.removeEventListener("storage", handler);
+      window.removeEventListener("storage", eventHandler);
     };
-  }, [handler]);
+  }, [eventHandler]);
 };


### PR DESCRIPTION
Fixes issue #23. 

Also contains a fix to avoid adding and removing events on every render by using the [`useEvent`](https://gist.github.com/diegohaz/695097a06f038a707c3a1b11e4e40195) custom hook.